### PR TITLE
Number formatting: Always show as thousands (K)

### DIFF
--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -260,6 +260,7 @@ ZSBT.NUMBER_FORMATS = {
     short1 = "Short (K/M/B, 1 decimal)",
     short2 = "Short (K/M/B, 2 decimals)",
     short0 = "Short (K/M/B, no decimals)",
+    shortK = "Thousands (K, 1 decimals)",
     sig3 = "Significant digits (3)",
 }
 
@@ -313,6 +314,11 @@ function ZSBT.FormatDisplayAmount(n)
         return short(1)
     elseif mode == "short2" then
         return short(2)
+    elseif mode == "shortK" then
+        local value = absN / 1000
+        local s = string.format("%s%.1fK", sign, value)
+        s = s:gsub("%.0K$", "K")
+        return s
     elseif mode == "sig3" then
         if absN < 1000 then
             return tostring(roundInt(n))


### PR DESCRIPTION
Hi,
I wanted to show the numbers always as thousands (Ks), because that way I don't have to interpret if the numbers are with or without K/M/B.

Tell me if you want some other naming or more options (more decimals, also for millions).